### PR TITLE
Feat/read ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+#PyCharm
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ docs/_build/
 target/
 
 #Ipython Notebook
-.ipynb_checkpoints
+.ipynb_checkpoints/
 
 #PyCharm
-.idea
+.idea/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "email": "author@place.edu",
   "github_username": "authorname",
   "project_name": "Memote model repository",
-  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "project_short_description": "Create a repository for maintaining a genome-scale metabolic model.",
   "release_date": "{% now 'local' %}",
   "year": "{{ cookiecutter.release_date[:4] }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,8 +9,8 @@
   "year": "{{ cookiecutter.release_date[:4] }}",
   "version": "0.1.0",
   "model": "default",
-  "yaml": "default",
   "model_path": "{{ cookiecutter.model | normalize }}",
+  "yaml": "default",
   "_extensions": [
     "memote.MemoteExtension"
   ]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,7 @@
   "year": "{{ cookiecutter.release_date[:4] }}",
   "version": "0.1.0",
   "model": "default",
+  "yaml": "default",
   "model_path": "{{ cookiecutter.model | normalize }}",
   "_extensions": [
     "memote.MemoteExtension"

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -30,7 +30,7 @@ fi
 git init
 git config user.email "{{ cookiecutter.email }}"
 git config user.name "{{ cookiecutter.full_name }}"
-# deploy hoooks
+# deploy hooks
 mv "pre-commit" ".git/hooks/"
 
 git add "." > "/dev/null"

--- a/tests/test_create_project.sh
+++ b/tests/test_create_project.sh
@@ -1,20 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -eu
+
+project="${1:-memote-model-repository}"
 
 cleanup() {
-    rm -rf memote_model_repository
+    rm -rf "${project}"
 }
 trap cleanup EXIT
 
 
 type cookiecutter
 
-echo "Running test script..."
 cookiecutter . --no-input
+
 (
-    cd ./memote_model_repository
-#    tox  # need a model that passes all tests first
+    echo "Running test script..."
+    cd "./${project}"
+    echo "Test for 'memote.ini'."
+    test -f "memote.ini"
+    echo "Test for 'model.xml'."
+    test -f "model.xml"
 )
 
 echo Done

--- a/{{cookiecutter.project_slug}}/memote.ini
+++ b/{{cookiecutter.project_slug}}/memote.ini
@@ -5,14 +5,13 @@ model.xml
 {{ cookiecutter.model | basename }}
 {%- endif %}
 location = Results
-write_alt = false
-json =
-mat =
+github_username = {{ cookiecutter.github_username }}
+github_repository = {{ cookiecutter.project_slug }}
+experimental = data/experiments.yml
+
+[pre_commit]
 yaml = {% if cookiecutter.yaml == "default" -%}
 default
 {%- else -%}
 {{ cookiecutter.yaml }}
 {%- endif %}
-github_username = {{ cookiecutter.github_username }}
-github_repository = {{ cookiecutter.project_slug }}
-experimental = data/experiments.yml

--- a/{{cookiecutter.project_slug}}/memote.ini
+++ b/{{cookiecutter.project_slug}}/memote.ini
@@ -5,10 +5,14 @@ model.xml
 {{ cookiecutter.model | basename }}
 {%- endif %}
 location = Results
-yaml =
 write_alt = false
 json =
 mat =
+yaml = {% if cookiecutter.yaml == "default" -%}
+default
+{%- else -%}
+{{ cookiecutter.yaml }}
+{%- endif %}
 github_username = {{ cookiecutter.github_username }}
 github_repository = {{ cookiecutter.project_slug }}
 experimental = data/experiments.yml

--- a/{{cookiecutter.project_slug}}/memote.ini
+++ b/{{cookiecutter.project_slug}}/memote.ini
@@ -5,6 +5,10 @@ model.xml
 {{ cookiecutter.model | basename }}
 {%- endif %}
 location = Results
+yaml =
+write_alt = false
+json =
+mat =
 github_username = {{ cookiecutter.github_username }}
 github_repository = {{ cookiecutter.project_slug }}
 experimental = data/experiments.yml

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -28,8 +28,7 @@ import os.path as osp
 from six.moves import configparser
 from subprocess import check_output
 
-from cobra.io import read_sbml_model, save_yaml_model, \
-    save_json_model, save_matlab_model
+from cobra.io import read_sbml_model, save_yaml_model
 
 LOGGER = logging.getLogger(__name__)
 config = configparser.ConfigParser()

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -43,10 +43,6 @@ def add_file(sbml_path, file_path, type):
     LOGGER.info("Writing {} '{}'.".format(type.upper(), file_path))
     if type == 'yaml':
         save_yaml_model(model, file_path, sort=True)
-    if type == 'json':
-        save_json_model(model, file_path)
-    if type == 'mat':
-        save_matlab_model(model, file_path)
 
     # Use subprocess rather than gitpython because gitpython cannot get a lock
     # on the git DB and thus raises an exception.
@@ -63,17 +59,6 @@ def main():
     else:
         yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
     add_file(in_path, yaml_path)
-    if config["memote"].getboolean("write_alt"):
-        if config["memote"]["json"] != '':
-            json_path = osp.basename(config["memote"]["json"])
-        else:
-            json_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
-        add_file(in_path, json_path)
-        if config["memote"]["mat"] != '':
-            mat_path = osp.basename(config["memote"]["mat"])
-        else:
-            mat_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
-        add_file(in_path, mat_path)
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -57,7 +57,7 @@ def main():
         yaml_path = osp.basename(config["memote"]["yaml"])
     else:
         yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
-    add_file(in_path, yaml_path)
+    add_file(in_path, yaml_path, 'yaml')
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -30,17 +30,15 @@ from subprocess import check_output
 
 from cobra.io import read_sbml_model, save_yaml_model
 
+
 LOGGER = logging.getLogger(__name__)
-config = configparser.ConfigParser()
-config.read('memote.ini')
-MEMOTE_MODEL = osp.basename(config["memote"]["model"])
 
 
 def add_file(sbml_path, file_path, file_type):
     LOGGER.info("Reading SBML '%s'.", sbml_path)
     model = read_sbml_model(sbml_path)
     LOGGER.info("Writing {} '{}'.".format(file_type.upper(), file_path))
-    if file_type == 'yaml':
+    if file_type == "yaml":
         save_yaml_model(model, file_path, sort=True)
     # Use subprocess rather than gitpython because gitpython cannot get a lock
     # on the git DB and thus raises an exception.
@@ -48,15 +46,24 @@ def add_file(sbml_path, file_path, file_type):
 
 
 def main():
-    in_path = MEMOTE_MODEL
-    if not osp.exists(in_path):
-        LOGGER.info("Model '%s' not found, skipping YAML addition.", in_path)
+    config_path = osp.join(
+        osp.dirname(__file__), osp.pardir, osp.pardir, "memote.ini")
+    if not osp.exists(config_path):
+        LOGGER.warning(
+            "No configuration file found. Expected '%s'. Skipping pre-commit.",
+            config_path)
         return
-    if config["pre_commit"]["yaml"] == 'default':
-        yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    model_path = osp.basename(config["memote"]["model"])
+    if not osp.exists(model_path):
+        LOGGER.info("Model '%s' not found, skipping YAML addition.", model_path)
+        return
+    if config["pre_commit"]["yaml"] == "default":
+        yaml_path = osp.splitext(model_path)[0] + ".yml"
     else:
         yaml_path = osp.basename(config["pre_commit"]["yaml"])
-    add_file(in_path, yaml_path, 'yaml')
+    add_file(model_path, yaml_path, "yaml")
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -55,14 +55,15 @@ def main():
         return
     config = configparser.ConfigParser()
     config.read(config_path)
-    model_path = osp.basename(config["memote"]["model"])
+    model_path = osp.basename(config.get("memote", "model"))
     if not osp.exists(model_path):
         LOGGER.info("Model '%s' not found, skipping YAML addition.", model_path)
         return
-    if config["pre_commit"]["yaml"] == "default":
+    yaml_path = config.get("pre_commit", "yaml")
+    if yaml_path == "default":
         yaml_path = osp.splitext(model_path)[0] + ".yml"
     else:
-        yaml_path = osp.basename(config["pre_commit"]["yaml"])
+        yaml_path = osp.basename(yaml_path)
     add_file(model_path, yaml_path, "yaml")
 
 

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -36,13 +36,12 @@ config.read('memote.ini')
 MEMOTE_MODEL = osp.basename(config["memote"]["model"])
 
 
-def add_file(sbml_path, file_path, type):
+def add_file(sbml_path, file_path, file_type):
     LOGGER.info("Reading SBML '%s'.", sbml_path)
     model = read_sbml_model(sbml_path)
-    LOGGER.info("Writing {} '{}'.".format(type.upper(), file_path))
-    if type == 'yaml':
+    LOGGER.info("Writing {} '{}'.".format(file_type.upper(), file_path))
+    if file_type == 'yaml':
         save_yaml_model(model, file_path, sort=True)
-
     # Use subprocess rather than gitpython because gitpython cannot get a lock
     # on the git DB and thus raises an exception.
     check_output(["git", "add", file_path])
@@ -53,10 +52,10 @@ def main():
     if not osp.exists(in_path):
         LOGGER.info("Model '%s' not found, skipping YAML addition.", in_path)
         return
-    if config["memote"]["yaml"] != 'default':
-        yaml_path = osp.basename(config["memote"]["yaml"])
-    else:
+    if config["pre_commit"]["yaml"] == 'default':
         yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
+    else:
+        yaml_path = osp.basename(config["pre_commit"]["yaml"])
     add_file(in_path, yaml_path, 'yaml')
 
 

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -28,7 +28,8 @@ import os.path as osp
 from six.moves import configparser
 from subprocess import check_output
 
-from cobra.io import read_sbml_model, save_yaml_model
+from cobra.io import read_sbml_model, save_yaml_model, \
+    save_json_model, save_matlab_model
 
 LOGGER = logging.getLogger(__name__)
 config = configparser.ConfigParser()
@@ -36,14 +37,20 @@ config.read('memote.ini')
 MEMOTE_MODEL = osp.basename(config["memote"]["model"])
 
 
-def add_yaml(sbml_path, yaml_path):
+def add_file(sbml_path, file_path, type):
     LOGGER.info("Reading SBML '%s'.", sbml_path)
     model = read_sbml_model(sbml_path)
-    LOGGER.info("Writing YAML '%s'.", yaml_path)
-    save_yaml_model(model, yaml_path, sort=True)
+    LOGGER.info("Writing {} '{}'.".format(type.upper(), file_path))
+    if type == 'yaml':
+        save_yaml_model(model, file_path, sort=True)
+    if type == 'json':
+        save_json_model(model, file_path)
+    if type == 'mat':
+        save_matlab_model(model, file_path)
+
     # Use subprocess rather than gitpython because gitpython cannot get a lock
     # on the git DB and thus raises an exception.
-    check_output(["git", "add", yaml_path])
+    check_output(["git", "add", file_path])
 
 
 def main():
@@ -51,8 +58,22 @@ def main():
     if not osp.exists(in_path):
         LOGGER.info("Model '%s' not found, skipping YAML addition.", in_path)
         return
-    out_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
-    add_yaml(in_path, out_path)
+    if config["memote"]["yaml"] != '':
+        yaml_path = osp.basename(config["memote"]["yaml"])
+    else:
+        yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
+    add_file(in_path, yaml_path)
+    if config["memote"].getboolean("write_alt"):
+        if config["memote"]["json"] != '':
+            json_path = osp.basename(config["memote"]["json"])
+        else:
+            json_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
+        add_file(in_path, json_path)
+        if config["memote"]["mat"] != '':
+            mat_path = osp.basename(config["memote"]["mat"])
+        else:
+            mat_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"
+        add_file(in_path, mat_path)
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -25,16 +25,15 @@ from __future__ import absolute_import
 
 import logging
 import os.path as osp
+from six.moves import configparser
 from subprocess import check_output
 
 from cobra.io import read_sbml_model, save_yaml_model
 
 LOGGER = logging.getLogger(__name__)
-MEMOTE_MODEL = osp.basename("{% if cookiecutter.model == "default" -%}
-model.xml
-{%- else -%}
-{{ cookiecutter.model | basename }}
-{%- endif %}")
+config = configparser.ConfigParser()
+config.read('memote.ini')
+MEMOTE_MODEL = osp.basename(config["memote"]["model"])
 
 
 def add_yaml(sbml_path, yaml_path):

--- a/{{cookiecutter.project_slug}}/pre-commit
+++ b/{{cookiecutter.project_slug}}/pre-commit
@@ -53,7 +53,7 @@ def main():
     if not osp.exists(in_path):
         LOGGER.info("Model '%s' not found, skipping YAML addition.", in_path)
         return
-    if config["memote"]["yaml"] != '':
+    if config["memote"]["yaml"] != 'default':
         yaml_path = osp.basename(config["memote"]["yaml"])
     else:
         yaml_path = osp.splitext(MEMOTE_MODEL)[0] + ".yml"


### PR DESCRIPTION
Enables the pre-commit hook to read the `memote.ini`.
Further allows the user to specify separate paths to writing either YAML, JSON or MAT files.

Fixes https://app.zenhub.com/workspace/o/opencobra/memote/issues/435