### PR TITLE
fix: replace repo.index.commit with subprocess.check_call

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,12 +47,19 @@ def main(model_path):
         writer.release()
     shutil.move("pre-commit", ".git/hooks/")
     repo.git.add(".")
-    repo.index.commit("feat: add initial structure for the model repository")
+    check_call(
+        ["git", "commit", "-m", "feat: add initial structure for the model repository"], 
+        shell=True
+    )
 
     # Set up the deployment branch.
     LOGGER.info("Configuring the deployment branch.")
-    repo.head.reference = git.Head(repo, "refs/heads/{{ cookiecutter.deployment }}")
+    check_call(
+    ["git", "checkout", "--orphan", "{{ cookiecutter.deployment }}"], 
+    shell=True
+    )
     # Remove unnecessary files.
+    LOGGER.info("Removing unnecessary files.")
     repo.git.rm("-r", "--cached", ".")
     ignore = {".git", "memote.ini", ".travis.yml"}
     for entry in os.listdir("."):
@@ -63,11 +70,14 @@ def main(model_path):
         else:
             shutil.rmtree(entry)
     # Add expected files.
+    LOGGER.info("Adding expected files such as memote.ini and .travis.yml.")
     os.mkdir("results")
     open("results/.keep", "w", encoding="utf-8").close()
     repo.index.add(["memote.ini", ".travis.yml", "results/.keep"])
-    repo.index.commit("feat: add initial deployment structure",
-                      parent_commits=None)
+    check_call(
+    ["git", "commit", "-m", "feat: add initial deployment structure"], 
+    shell=True
+    )
     # Add remote according to cookiecutter value.
     repo.create_remote(
         "origin",
@@ -81,7 +91,10 @@ def main(model_path):
     LOGGER.info("Generate the first history report.")
     check_call(["memote", "report", "history"])
     repo.index.add(["index.html"])
-    repo.index.commit("feat: initial history report")
+    check_call(
+        ["git", "commit", "-m", "feat: initial history report"], 
+        shell=True
+    )
     repo.heads.master.checkout()
 
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -48,15 +48,14 @@ def main(model_path):
     shutil.move("pre-commit", ".git/hooks/")
     repo.git.add(".")
     check_call(
-        ["git", "commit", "-m", "feat: add initial structure for the model repository"], 
-        shell=True
+        ["git", "commit",
+         "-m", "feat: add initial structure for the model repository"]
     )
 
     # Set up the deployment branch.
     LOGGER.info("Configuring the deployment branch.")
     check_call(
-    ["git", "checkout", "--orphan", "{{ cookiecutter.deployment }}"], 
-    shell=True
+        ["git", "checkout", "--orphan", "{{ cookiecutter.deployment }}"]
     )
     # Remove unnecessary files.
     LOGGER.info("Removing unnecessary files.")
@@ -75,13 +74,13 @@ def main(model_path):
     open("results/.keep", "w", encoding="utf-8").close()
     repo.index.add(["memote.ini", ".travis.yml", "results/.keep"])
     check_call(
-    ["git", "commit", "-m", "feat: add initial deployment structure"], 
-    shell=True
+        ["git", "commit", "-m", "feat: add initial deployment structure"]
     )
     # Add remote according to cookiecutter value.
     repo.create_remote(
         "origin",
-        "git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}.git"
+        "git@github.com:{{ cookiecutter.github_username }}"
+        "/{{ cookiecutter.project_slug }}.git"
     )
 
     repo.heads.master.checkout()
@@ -92,8 +91,7 @@ def main(model_path):
     check_call(["memote", "report", "history"])
     repo.index.add(["index.html"])
     check_call(
-        ["git", "commit", "-m", "feat: initial history report"], 
-        shell=True
+        ["git", "commit", "-m", "feat: initial history report"]
     )
     repo.heads.master.checkout()
 


### PR DESCRIPTION
Testing `memote new` line by line on my windows machine I found that it fails whenever `repo.index.commit` is called. The error message is a somewhat cryptic ```
OSError: [WinError 193] %1 is not a valid Win32 application```


A subprocess call of `git` however seems to fix this on windows.
