### PR TITLE
Fix: model.xml as user input corner case

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,7 +36,8 @@ def main(model_path):
         target = basename(model_path)
         LOGGER.info("copying '{}' -> '{}'".format(model_path, target))
         shutil.copy2(model_path, target)
-        os.remove("model.xml")
+        if target != "model.xml":
+            os.remove("model.xml")
 
     # Set up the repository with the master branch.
     LOGGER.info("Configuring git repository.")


### PR DESCRIPTION
### Description

My model is called `model.xml` and it was being removed after copying it during the post_gen hook, failing the cookicutter generation when running memote.

### Implementation

Only remove `model.xml` if it is not the actual file name of the user's input.