### PR TITLE
PR memote diff comment (from master)

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/diff-pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/diff-pr.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: '3.9'
     - name: Install dependencies
       run: |
-        python -m pip install memote==0.13.0
+        python -m pip install --upgrade memote
     - name: Run memote on deployment branch
       run: |
         model=$(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /model/) print $2}' memote.ini | tr -d ' ')

--- a/{{cookiecutter.project_slug}}/.github/workflows/diff-pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/diff-pr.yml
@@ -1,0 +1,41 @@
+name: memote-diff
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install memote==0.13.0
+    - name: Run memote on deployment branch
+      run: |
+        model=$(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /model/) print $2}' memote.ini | tr -d ' ')
+        deployment=$(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /deployment/) print $2}' memote.ini | tr -d ' ')
+        git show "origin/master:${model}" > "prev_${model}"
+        memote report diff --filename "diff${GITHUB_SHA}.html" "$model" "prev_${model}"
+        git checkout $deployment
+        git pull
+        git add "diff${GITHUB_SHA}.html"
+        git config --global user.email {{ cookiecutter.email }}
+        git config --global user.name {{ cookiecutter.github_username }}
+        git commit -m 'test: add diff report'
+        git push
+    - name: Post PR comment
+      uses: JoseThen/comment-pr@v1.1.1
+      with:
+        comment: {{ 'Memote diff was generated at https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/diff${{ github.sha }}' }}
+        GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+


### PR DESCRIPTION
### Description

Show a diff between the model in the main branch and the one in the pull request.

Demonstration [here](https://github.com/carrascomj/ecoli_memotum/pull/2#issuecomment-1034989307):

![image](https://user-images.githubusercontent.com/46683255/153431119-943db603-f4a9-4eab-b978-5278291e6113.png)

### Implementation

Add a github action that runs `memote diff` between the model at the master branch and the one at the PR. Then, publish the diff to the deployment branch and generate a comment in the PR. 

Credits to @BenjaSanchez for the idea a long time ago.
